### PR TITLE
Add report-to CSP directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ SecureHeaders::Configuration.default do |config|
     style_src_attr: %w('unsafe-inline'),
     worker_src: %w('self'),
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
-    report_uri: %w(https://report-uri.io/example-csp)
+    report_uri: %w(https://report-uri.io/example-csp),
+    report_to: %w(example-csp)
   }
   # This is available only from 3.5.0; use the `report_only: true` setting for 3.4.1 and below.
   config.csp_report_only = config.csp.merge({
     img_src: %w(somewhereelse.com),
-    report_uri: %w(https://report-uri.io/example-csp-report-only)
+    report_uri: %w(https://report-uri.io/example-csp-report-only),
+    report_to: %w(example-csp-report-only)
   })
 end
 ```

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -46,8 +46,8 @@ module SecureHeaders
     private
 
     # Private: converts the config object into a string representing a policy.
-    # Places default-src at the first directive and report-uri as the last. All
-    # others are presented in alphabetical order.
+    # Places default-src at the first directive, report-uri second to last and report-to as the
+    # last. All others are presented in alphabetical order.
     #
     # Returns a content security policy header value.
     def build_value
@@ -130,7 +130,7 @@ module SecureHeaders
         source_list = populate_nonces(directive, source_list)
         source_list = reject_all_values_if_none(source_list)
 
-        unless directive == REPORT_URI || @preserve_schemes
+        unless [REPORT_URI, REPORT_TO].include?(directive) || @preserve_schemes
           source_list = strip_source_schemes(source_list)
         end
         source_list.uniq
@@ -185,6 +185,7 @@ module SecureHeaders
         DEFAULT_SRC,
         BODY_DIRECTIVES,
         REPORT_URI,
+        REPORT_TO
       ].flatten
     end
 

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -81,6 +81,7 @@ module SecureHeaders
     SCRIPT_SRC_ATTR = :script_src_attr
     STYLE_SRC_ELEM = :style_src_elem
     STYLE_SRC_ATTR = :style_src_attr
+    REPORT_TO = :report_to
 
     DIRECTIVES_3_0 = [
       DIRECTIVES_2_0,
@@ -93,7 +94,8 @@ module SecureHeaders
       SCRIPT_SRC_ELEM,
       SCRIPT_SRC_ATTR,
       STYLE_SRC_ELEM,
-      STYLE_SRC_ATTR
+      STYLE_SRC_ATTR,
+      REPORT_TO
     ].flatten.freeze
 
     # Experimental directives - these vary greatly in support
@@ -110,9 +112,9 @@ module SecureHeaders
 
     ALL_DIRECTIVES = (DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0 + DIRECTIVES_EXPERIMENTAL).uniq.sort
 
-    # Think of default-src and report-uri as the beginning and end respectively,
+    # Think of default-src as the beginning, report-uri and report-to as the end,
     # everything else is in between.
-    BODY_DIRECTIVES = ALL_DIRECTIVES - [DEFAULT_SRC, REPORT_URI]
+    BODY_DIRECTIVES = ALL_DIRECTIVES - [DEFAULT_SRC, REPORT_URI, REPORT_TO]
 
     DIRECTIVE_VALUE_TYPES = {
       BASE_URI                  => :source_list,
@@ -131,6 +133,7 @@ module SecureHeaders
       PLUGIN_TYPES              => :media_type_list,
       REQUIRE_SRI_FOR           => :require_sri_for_list,
       REQUIRE_TRUSTED_TYPES_FOR => :require_trusted_types_for_list,
+      REPORT_TO                 => :source_list,
       REPORT_URI                => :source_list,
       PREFETCH_SRC              => :source_list,
       SANDBOX                   => :sandbox_list,

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -71,6 +71,11 @@ module SecureHeaders
         expect(csp.value).to eq("default-src https:; report-uri https://example.org")
       end
 
+      it "does not remove schemes from report-to values" do
+        csp = ContentSecurityPolicy.new(default_src: %w(https:), report_to: %w(https://example.org))
+        expect(csp.value).to eq("default-src https:; report-to https://example.org")
+      end
+
       it "does not remove schemes when :preserve_schemes is true" do
         csp = ContentSecurityPolicy.new(default_src: %w(https://example.org), preserve_schemes: true)
         expect(csp.value).to eq("default-src https://example.org")

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -55,6 +55,7 @@ module SecureHeaders
           style_src_attr: %w(example.com),
           trusted_types: %w(abcpolicy),
 
+          report_to: %w(https://example.com/uri-directive),
           report_uri: %w(https://example.com/uri-directive),
         }
 


### PR DESCRIPTION
## All PRs:

* [ ] Has tests
* [ ] Documentation updated

## Adding a new header

Generally, adding a new header is always OK.

* Is the header supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the header?
* Where does the specification live?

## Adding a new CSP directive

* Is the directive supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the directive?

